### PR TITLE
feat:seg_api coord & seg_api path

### DIFF
--- a/seg_api/app/frontend/frontend.py
+++ b/seg_api/app/frontend/frontend.py
@@ -15,15 +15,17 @@ def main():
     st.title("Segment clothes")
     st.markdown("---")
     st.header("Upload Image")
-
+    seg_state = False
     if "result" not in st.session_state:
         st.session_state["result"] = None
+        seg_state = True
     uploaded_file = st.file_uploader("파일을 업로드하세요.", type=["png", "jpg", "jpeg"])
-    if uploaded_file is not None:
+    if uploaded_file is not None and seg_state is None:
+        print("출력xxxxx")
         st.write("업로드된 파일:", uploaded_file.name)
         file_name = uploaded_file.name
         if st.button('Seg start!', key="start_bt"):
-            save_path = os.path.join("/opt/ml/seg_app/app/input", file_name)
+            save_path = os.path.join("./app/input", file_name)
             with open(save_path, "wb") as f:
                 f.write(uploaded_file.getbuffer())
 


### PR DESCRIPTION
## Background
- seg_api가 작동하는 것을 확인하기 위해 임의로 좌표를 설정해주었어서 수정해주었습니다.
- 이미지 경로가 절대 경로로 되어 있어, 클론받는 사람들마다 수정해줄 팔요가 있어서 상대경로로 바꿔주었습니다.

## Works
-  마우스로 좌표를 찍으면 그 좌표를 기반으로 segment가 이뤄집니다
- 상대경로로 수정해서 그냥 실행하면 문제없이 작동합니다.

### 실행 
프론트 : `streamlit run app/frontend/frontend.py`
백엔드 : `python -m app`

실행할 때, 모델이 필요한데, git 용량 이슈로 인해 올리지 못했습니다. 
**저에게 파일을 요청**하시거나 
```
import os
import urllib.request

url = "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth"
save_dir = "/opt/ml/weights"
filename = os.path.join(save_dir, "sam_vit_h_4b8939.pth")

os.makedirs(save_dir, exist_ok=True)

urllib.request.urlretrieve(url, filename)

```
**다음 코드를 통해 파일을 저장**한 후,  실행하시면 문제없이 작동합니다
