### PR TITLE
fix: request segmentation api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@ __pycache__
 .empty
 
 # frontend
+frontend/accounts.yaml
+frontend/api_address.yaml
 
 # backend

--- a/frontend/Home.py
+++ b/frontend/Home.py
@@ -10,10 +10,20 @@ import streamlit as st
 from streamlit_extras.switch_page_button import switch_page
 
 # custom-modules
+from utils import init_session_state
 
+# built-in library
+import yaml
+from yaml.loader import SafeLoader
 
 
 if __name__ == "__main__":
+    # api별 ip 주소를 session state에 등록
+    with open("./api_address.yaml") as file:
+        api_address = yaml.load(file, Loader=SafeLoader)
+
+    init_session_state(list(api_address.items()))
+
     # 프로젝트 제목
     st.title(":shirt: 쇼핑의 기본, \"멋탠다드\"")
     st.markdown("---")

--- a/frontend/accounts.yaml
+++ b/frontend/accounts.yaml
@@ -1,5 +1,3 @@
-# 회원가입 시 사용자의 정보가 여기 저장됩니다.
-# 기본 형태를 보여주기 위해 작성되었고, 실제 계정 정보가 업데이트되면 push하지 않아야 합니다.
 cookie:
   expiry_days: 0
   key: random_signature_key
@@ -10,6 +8,10 @@ credentials:
       email: noname@gmail.com
       name: No Name
       password: $2b$12$4LM6Q7TnH4PaN/amrNJ/Uu1sVipMwY4AQp//3MhZeLM7B6lNwHszu
+    test01:
+      email: test@test.com
+      name: test01
+      password: $2b$12$.9Exp0hdupWMv0sZIR5IVeKY3RhDGhwSnoV/3CtO73Qw4phtgvkZa
 preauthorized:
   emails:
   - melsby@gmail.com

--- a/frontend/pages/04_상품_검색.py
+++ b/frontend/pages/04_상품_검색.py
@@ -1,7 +1,16 @@
 # streamlit
 import streamlit as st
+from streamlit_extras.streamlit_image_coordinates import streamlit_image_coordinates
+from streamlit_image_select import image_select
+
+# external-library
+from PIL import Image
 
 # built-in library
+import requests
+import os.path as osp
+import io
+import base64
 
 # custom-library
 from utils import init_session_state
@@ -12,19 +21,55 @@ if __name__ == "__main__":
         st.title("상품 검색 서비스")
 
         # 필요한 state 초기화
-        init_session_state([("result", None), 
-                            ("x", None), 
-                            ("y", None), 
-                            ("save_path", None)])
+        init_session_state([("result", None)])
         
-
-        upload_file = st.file_uploader("검색을 원하는 상품 사진을 업로드해주세요!", type=["png", "jpg", "jpeg"])
+        # 사진 업로드
+        uploaded_img = st.file_uploader("검색하고 싶은 상품 사진을 업로드해주세요!", 
+                                        type=["png", "jpg", "jpeg"])
 
         # 사용자가 파일을 업로드했다면
-        if upload_file is not None:
-            file_name = upload_file.name
+        if uploaded_img is not None:
+            img_bytes = io.BytesIO(uploaded_img.read())
 
-            # TODO: seg 쪽 api가 upload file로 바뀐다고 하지 않았었나..? 체크해보기
+            # TODO: 이미지 크기 조정을 생각해보기(단, PIL.Image.open을 사용 시 backend로 송신할 때 에러남)
+            # 시각화
+            st.markdown("<div style='display: flex; justify-content: center; align-items: center;'> \
+                        <span style='color:#FF0000; text-align: center;'>무늬가 아닌, 옷 전체적인 부분을 누른다면 정확도가 더욱 높아집니다 :-)</span> \
+                        </div>", unsafe_allow_html=True)
+            img = Image.open(uploaded_img)
+
+            # 좌표 설정
+            coordinates = streamlit_image_coordinates(
+                img,
+                key = "lacal2"
+            )
+
+            if coordinates is not None:
+                x, y = coordinates['x'], coordinates['y']
+                
+                # segmentation api 호출
+                files = {"img": img_bytes}
+                response = requests.post(f"{st.sessesion_state.segmentation}/seg?x={x}&y={y}", files=files)
+                
+                segmented_imgs = []
+                bytes_list = response.json()
+                for bytes_data in bytes_list:
+                    image_data = base64.b64decode(bytes_data)                
+                    image = Image.open(io.BytesIO(image_data))
+                    segmented_imgs.append(image)
+
+                st.success('서버 전송 완료', icon="✅")
+                
+                img = image_select("선택해주세요", segmented_imgs)
+
+                # TODO: 속도 이슈가 있음 -> st.stop() 혹은 st.experimental_rerun() 사용, 혹은 switch_page()를 이용해서 구현하는 걸로 (조금 더 생각해보기)
+                if st.button("이걸로 검색하시겠어요?"):
+                    st.write('something')
+                    st.success("success")
+
+                    # TODO: 검색 API 요청할 때 작성할 부분
+                    # response2 = 
+
     else:
         st.header("로그인 후 이용해주세요.")
     


### PR DESCRIPTION
## Background
- frontend baseline의 상품 검색 페이지에서 segmentation api를 호출해야 합니다.

## Works
- `.gitignore` : push하지 않을 파일들을 추가했습니다. `api_address.yaml` 파일은 api 별 ip 주소를 담아둔 파일로,
로컬에서만 사용합니다.
- `Home.py` : api별 ip 주소를 session_state에 등록하는 코드가 추가되었습니다. 기능별 페이지에서 session state에 저장된
ip 주소를 불러다가 사용합니다. 이는 서버의 ip 주소를 코드 상에 노출시키지 않기 위함입니다.
- `accounts.yaml` : 회원가입을 통해 계정 정보가 저장됩니다. 테스트용 계정으로 `username: test01`, `pw: 01`을 사용해주세요.
- `04_상품_검색.py` : segmentation api를 호출하는 코드가 추가되었습니다. 현재 업로드한 이미지와 inference 결과 이미지를 따로 저장하지는 않고, data 자체를 주고받을 수 있도록 구현된 상태입니다.

## See Also
- #9 