### PR TITLE
fix : image_select padding

### DIFF
--- a/frontend/pages/04_상품_검색.py
+++ b/frontend/pages/04_상품_검색.py
@@ -1,6 +1,8 @@
 # streamlit
 import streamlit as st
-from streamlit_extras.streamlit_image_coordinates import streamlit_image_coordinates
+# from streamlit_extras.streamlit_image_coordinates import streamlit_image_coordinates
+# from streamlit_image_select import image_select
+from streamlit_image_coordinates import streamlit_image_coordinates
 from streamlit_image_select import image_select
 
 # external-library
@@ -49,14 +51,26 @@ if __name__ == "__main__":
                 
                 # segmentation api 호출
                 files = {"img": img_bytes}
-                response = requests.post(f"{st.sessesion_state.segmentation}/seg?x={x}&y={y}", files=files)
+                # response = requests.post(f"{st.sessesion_state.segmentation}/seg?x={x}&y={y}", files=files)
+                response = requests.post(f"http://49.50.164.40:30006/seg?x={coordinates['x']}&y={coordinates['y']}", files=files)
                 
                 segmented_imgs = []
                 bytes_list = response.json()
                 for bytes_data in bytes_list:
                     image_data = base64.b64decode(bytes_data)                
                     image = Image.open(io.BytesIO(image_data))
-                    segmented_imgs.append(image)
+                    if image.size[0] > image.size[1] : 
+                        sz = image.size[0]
+                        new_img = Image.new(image.mode, (sz, sz), (0,0,0))
+                        new_img.paste(image,(0,int((image.size[0]-image.size[1])/2)))
+                    else :
+                        sz = image.size[1]
+                        new_img = Image.new(image.mode, (sz, sz), (0,0,0))
+                        new_img.paste(image, (int((image.size[1]-image.size[0])/2),0))
+                    segmented_imgs.append(new_img)
+                
+
+    
 
                 st.success('서버 전송 완료', icon="✅")
                 


### PR DESCRIPTION
## Background
- Image select module에서 가로, 세로 방향으로 긴 이미지들이 잘리는 현상 발견

## Feature
- image의 가로 세로가 1:1 비율이 되도록 zero padding

## Notice 
- image-select module의 use_container_width parameter를 False로 할 경우 정사각형으로 padding된 이미지가 그대로 보이지만, True로 할 경우 select 할 이미지 수에 맞춰 자동으로 크기가 늘려져 다시 일부가 잘린다는 문제가 있음. 